### PR TITLE
Fix perf owner check

### DIFF
--- a/Bukkit/build.gradle
+++ b/Bukkit/build.gradle
@@ -10,7 +10,7 @@ dependencies {
     implementation(project(":Core"))
     compile(project(":Core"))
     implementation("org.spigotmc:spigot-api:1.12.2-R0.1-SNAPSHOT")
-    implementation("net.milkbowl.vault:VaultAPI:1.7") {
+    implementation("com.github.MilkBowl:VaultAPI:1.7") {
         exclude module: 'bukkit'
     }
     implementation("me.clip:placeholderapi:2.10.9")

--- a/Bukkit/pom.xml
+++ b/Bukkit/pom.xml
@@ -45,7 +45,7 @@
       <scope>runtime</scope>
     </dependency>
     <dependency>
-      <groupId>net.milkbowl.vault</groupId>
+      <groupId>com.github.MilkBowl</groupId>
       <artifactId>VaultAPI</artifactId>
       <version>1.7</version>
       <scope>runtime</scope>

--- a/Core/src/main/java/com/intellectualcrafters/plot/object/PlotArea.java
+++ b/Core/src/main/java/com/intellectualcrafters/plot/object/PlotArea.java
@@ -532,7 +532,7 @@ public abstract class PlotArea {
 
     public boolean hasPlot(UUID uuid) {
         for (Entry<PlotId, Plot> entry : this.plots.entrySet()) {
-            if (entry.getValue().isOwner(uuid)) return true;
+            if (entry.getValue().isOwnerAbs(uuid)) return true;
         }
         return false;
     }


### PR DESCRIPTION
If a (very) large amount of plots is given, PlotSquared#hasPlot(UUID) has noticable performance problems.

Plot#isOwner(UUID) is called within PlotArea#hasPlot(UUID), causing PS to iterate through all merges of the plot via Plot#getConnectedPlots().

That is unnecessary. Since PlotArea#hasPlot(UUID) iterates through all plots, including non-base plots, it is not required to iterate through a plots merges per plot iteration.

This PR includes a massive performance improvement for servers with large amounts of plots, specifically with many merged plots.


Additionally, the Vault dependency is updated.